### PR TITLE
Add VictoriaMetrics histogram support

### DIFF
--- a/proto/proto_model.proto
+++ b/proto/proto_model.proto
@@ -27,6 +27,7 @@ enum MetricType {
   SUMMARY    = 2;
   UNTYPED    = 3;
   HISTOGRAM  = 4;
+  VMHISTOGRAM = 5;
 }
 
 message Gauge {
@@ -71,6 +72,7 @@ message Metric {
   optional Untyped   untyped      = 5;
   optional Histogram histogram    = 7;
   optional int64     timestamp_ms = 6;
+  optional VMHistogram vm_histogram = 8;
 }
 
 message MetricFamily {
@@ -78,4 +80,15 @@ message MetricFamily {
   optional string     help   = 2;
   optional MetricType type   = 3;
   repeated Metric     metric = 4;
+}
+
+message VMHistogram {
+  optional uint64 sample_count = 1;
+  optional double sample_sum = 2;
+  repeated VMRange ranges = 3;
+}
+
+message VMRange {
+  optional string range = 1;
+  optional uint64 count = 2;
 }

--- a/proto/proto_model.proto
+++ b/proto/proto_model.proto
@@ -65,13 +65,13 @@ message Bucket {
 }
 
 message Metric {
-  repeated LabelPair label        = 1;
-  optional Gauge     gauge        = 2;
-  optional Counter   counter      = 3;
-  optional Summary   summary      = 4;
-  optional Untyped   untyped      = 5;
-  optional Histogram histogram    = 7;
-  optional int64     timestamp_ms = 6;
+  repeated LabelPair   label        = 1;
+  optional Gauge       gauge        = 2;
+  optional Counter     counter      = 3;
+  optional Summary     summary      = 4;
+  optional Untyped     untyped      = 5;
+  optional Histogram   histogram    = 7;
+  optional int64       timestamp_ms = 6;
   optional VMHistogram vm_histogram = 8;
 }
 

--- a/proto/proto_model.rs
+++ b/proto/proto_model.rs
@@ -114,7 +114,7 @@ impl ::protobuf::Message for LabelPair {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -147,7 +147,7 @@ impl ::protobuf::Message for LabelPair {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.name.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -235,13 +235,13 @@ impl ::protobuf::Clear for LabelPair {
 }
 
 impl ::std::fmt::Debug for LabelPair {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for LabelPair {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -285,7 +285,7 @@ impl ::protobuf::Message for Gauge {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -316,7 +316,7 @@ impl ::protobuf::Message for Gauge {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.value {
             os.write_double(1, v)?;
         }
@@ -395,13 +395,13 @@ impl ::protobuf::Clear for Gauge {
 }
 
 impl ::std::fmt::Debug for Gauge {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Gauge {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -445,7 +445,7 @@ impl ::protobuf::Message for Counter {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -476,7 +476,7 @@ impl ::protobuf::Message for Counter {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.value {
             os.write_double(1, v)?;
         }
@@ -555,13 +555,13 @@ impl ::protobuf::Clear for Counter {
 }
 
 impl ::std::fmt::Debug for Counter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Counter {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -625,7 +625,7 @@ impl ::protobuf::Message for Quantile {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -666,7 +666,7 @@ impl ::protobuf::Message for Quantile {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.quantile {
             os.write_double(1, v)?;
         }
@@ -754,13 +754,13 @@ impl ::protobuf::Clear for Quantile {
 }
 
 impl ::std::fmt::Debug for Quantile {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Quantile {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -855,7 +855,7 @@ impl ::protobuf::Message for Summary {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -903,7 +903,7 @@ impl ::protobuf::Message for Summary {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.sample_count {
             os.write_uint64(1, v)?;
         }
@@ -1002,13 +1002,13 @@ impl ::protobuf::Clear for Summary {
 }
 
 impl ::std::fmt::Debug for Summary {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Summary {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1052,7 +1052,7 @@ impl ::protobuf::Message for Untyped {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1083,7 +1083,7 @@ impl ::protobuf::Message for Untyped {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.value {
             os.write_double(1, v)?;
         }
@@ -1162,13 +1162,13 @@ impl ::protobuf::Clear for Untyped {
 }
 
 impl ::std::fmt::Debug for Untyped {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Untyped {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1263,7 +1263,7 @@ impl ::protobuf::Message for Histogram {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1311,7 +1311,7 @@ impl ::protobuf::Message for Histogram {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.sample_count {
             os.write_uint64(1, v)?;
         }
@@ -1410,13 +1410,13 @@ impl ::protobuf::Clear for Histogram {
 }
 
 impl ::std::fmt::Debug for Histogram {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Histogram {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1480,7 +1480,7 @@ impl ::protobuf::Message for Bucket {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1521,7 +1521,7 @@ impl ::protobuf::Message for Bucket {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.cumulative_count {
             os.write_uint64(1, v)?;
         }
@@ -1609,13 +1609,13 @@ impl ::protobuf::Clear for Bucket {
 }
 
 impl ::std::fmt::Debug for Bucket {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Bucket {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1630,6 +1630,7 @@ pub struct Metric {
     untyped: ::protobuf::SingularPtrField<Untyped>,
     histogram: ::protobuf::SingularPtrField<Histogram>,
     timestamp_ms: ::std::option::Option<i64>,
+    vm_histogram: ::protobuf::SingularPtrField<VMHistogram>,
     // special fields
     pub unknown_fields: ::protobuf::UnknownFields,
     pub cached_size: ::protobuf::CachedSize,
@@ -1848,6 +1849,39 @@ impl Metric {
     pub fn get_timestamp_ms(&self) -> i64 {
         self.timestamp_ms.unwrap_or(0)
     }
+
+    // optional .io.prometheus.client.VMHistogram vm_histogram = 8;
+
+    pub fn clear_vm_histogram(&mut self) {
+        self.vm_histogram.clear();
+    }
+
+    pub fn has_vm_histogram(&self) -> bool {
+        self.vm_histogram.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_vm_histogram(&mut self, v: VMHistogram) {
+        self.vm_histogram = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_vm_histogram(&mut self) -> &mut VMHistogram {
+        if self.vm_histogram.is_none() {
+            self.vm_histogram.set_default();
+        }
+        self.vm_histogram.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_vm_histogram(&mut self) -> VMHistogram {
+        self.vm_histogram.take().unwrap_or_else(|| VMHistogram::new())
+    }
+
+    pub fn get_vm_histogram(&self) -> &VMHistogram {
+        self.vm_histogram.as_ref().unwrap_or_else(|| VMHistogram::default_instance())
+    }
 }
 
 impl ::protobuf::Message for Metric {
@@ -1882,10 +1916,15 @@ impl ::protobuf::Message for Metric {
                 return false;
             }
         };
+        for v in &self.vm_histogram {
+            if !v.is_initialized() {
+                return false;
+            }
+        };
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1913,6 +1952,9 @@ impl ::protobuf::Message for Metric {
                     }
                     let tmp = is.read_int64()?;
                     self.timestamp_ms = ::std::option::Option::Some(tmp);
+                },
+                8 => {
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.vm_histogram)?;
                 },
                 _ => {
                     ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
@@ -1953,12 +1995,16 @@ impl ::protobuf::Message for Metric {
         if let Some(v) = self.timestamp_ms {
             my_size += ::protobuf::rt::value_size(6, v, ::protobuf::wire_format::WireTypeVarint);
         }
+        if let Some(ref v) = self.vm_histogram.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         for v in &self.label {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -1991,6 +2037,11 @@ impl ::protobuf::Message for Metric {
         }
         if let Some(v) = self.timestamp_ms {
             os.write_int64(6, v)?;
+        }
+        if let Some(ref v) = self.vm_histogram.as_ref() {
+            os.write_tag(8, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
         }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -2069,6 +2120,11 @@ impl ::protobuf::Message for Metric {
                     |m: &Metric| { &m.timestamp_ms },
                     |m: &mut Metric| { &mut m.timestamp_ms },
                 ));
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<VMHistogram>>(
+                    "vm_histogram",
+                    |m: &Metric| { &m.vm_histogram },
+                    |m: &mut Metric| { &mut m.vm_histogram },
+                ));
                 ::protobuf::reflect::MessageDescriptor::new::<Metric>(
                     "Metric",
                     fields,
@@ -2098,18 +2154,19 @@ impl ::protobuf::Clear for Metric {
         self.clear_untyped();
         self.clear_histogram();
         self.clear_timestamp_ms();
+        self.clear_vm_histogram();
         self.unknown_fields.clear();
     }
 }
 
 impl ::std::fmt::Debug for Metric {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Metric {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -2258,7 +2315,7 @@ impl ::protobuf::Message for MetricFamily {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -2304,7 +2361,7 @@ impl ::protobuf::Message for MetricFamily {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.name.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -2412,13 +2469,473 @@ impl ::protobuf::Clear for MetricFamily {
 }
 
 impl ::std::fmt::Debug for MetricFamily {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for MetricFamily {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
+pub struct VMHistogram {
+    // message fields
+    sample_count: ::std::option::Option<u64>,
+    sample_sum: ::std::option::Option<f64>,
+    ranges: ::protobuf::RepeatedField<VMRange>,
+    // special fields
+    pub unknown_fields: ::protobuf::UnknownFields,
+    pub cached_size: ::protobuf::CachedSize,
+}
+
+impl VMHistogram {
+    pub fn new() -> VMHistogram {
+        ::std::default::Default::default()
+    }
+
+    // optional uint64 sample_count = 1;
+
+    pub fn clear_sample_count(&mut self) {
+        self.sample_count = ::std::option::Option::None;
+    }
+
+    pub fn has_sample_count(&self) -> bool {
+        self.sample_count.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_sample_count(&mut self, v: u64) {
+        self.sample_count = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_sample_count(&self) -> u64 {
+        self.sample_count.unwrap_or(0)
+    }
+
+    // optional double sample_sum = 2;
+
+    pub fn clear_sample_sum(&mut self) {
+        self.sample_sum = ::std::option::Option::None;
+    }
+
+    pub fn has_sample_sum(&self) -> bool {
+        self.sample_sum.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_sample_sum(&mut self, v: f64) {
+        self.sample_sum = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_sample_sum(&self) -> f64 {
+        self.sample_sum.unwrap_or(0.)
+    }
+
+    // repeated .io.prometheus.client.VMRange ranges = 3;
+
+    pub fn clear_ranges(&mut self) {
+        self.ranges.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_ranges(&mut self, v: ::protobuf::RepeatedField<VMRange>) {
+        self.ranges = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_ranges(&mut self) -> &mut ::protobuf::RepeatedField<VMRange> {
+        &mut self.ranges
+    }
+
+    // Take field
+    pub fn take_ranges(&mut self) -> ::protobuf::RepeatedField<VMRange> {
+        ::std::mem::replace(&mut self.ranges, ::protobuf::RepeatedField::new())
+    }
+
+    pub fn get_ranges(&self) -> &[VMRange] {
+        &self.ranges
+    }
+}
+
+impl ::protobuf::Message for VMHistogram {
+    fn is_initialized(&self) -> bool {
+        for v in &self.ranges {
+            if !v.is_initialized() {
+                return false;
+            }
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_uint64()?;
+                    self.sample_count = ::std::option::Option::Some(tmp);
+                },
+                2 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeFixed64 {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_double()?;
+                    self.sample_sum = ::std::option::Option::Some(tmp);
+                },
+                3 => {
+                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.ranges)?;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if let Some(v) = self.sample_count {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
+        }
+        if let Some(v) = self.sample_sum {
+            my_size += 9;
+        }
+        for value in &self.ranges {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.sample_count {
+            os.write_uint64(1, v)?;
+        }
+        if let Some(v) = self.sample_sum {
+            os.write_double(2, v)?;
+        }
+        for v in &self.ranges {
+            os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
+        };
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        Self::descriptor_static()
+    }
+
+    fn new() -> VMHistogram {
+        VMHistogram::new()
+    }
+
+    fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
+                    "sample_count",
+                    |m: &VMHistogram| { &m.sample_count },
+                    |m: &mut VMHistogram| { &mut m.sample_count },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeDouble>(
+                    "sample_sum",
+                    |m: &VMHistogram| { &m.sample_sum },
+                    |m: &mut VMHistogram| { &mut m.sample_sum },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<VMRange>>(
+                    "ranges",
+                    |m: &VMHistogram| { &m.ranges },
+                    |m: &mut VMHistogram| { &mut m.ranges },
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<VMHistogram>(
+                    "VMHistogram",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+
+    fn default_instance() -> &'static VMHistogram {
+        static mut instance: ::protobuf::lazy::Lazy<VMHistogram> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const VMHistogram,
+        };
+        unsafe {
+            instance.get(VMHistogram::new)
+        }
+    }
+}
+
+impl ::protobuf::Clear for VMHistogram {
+    fn clear(&mut self) {
+        self.clear_sample_count();
+        self.clear_sample_sum();
+        self.clear_ranges();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for VMHistogram {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for VMHistogram {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
+pub struct VMRange {
+    // message fields
+    range: ::protobuf::SingularField<::std::string::String>,
+    count: ::std::option::Option<u64>,
+    // special fields
+    pub unknown_fields: ::protobuf::UnknownFields,
+    pub cached_size: ::protobuf::CachedSize,
+}
+
+impl VMRange {
+    pub fn new() -> VMRange {
+        ::std::default::Default::default()
+    }
+
+    // optional string range = 1;
+
+    pub fn clear_range(&mut self) {
+        self.range.clear();
+    }
+
+    pub fn has_range(&self) -> bool {
+        self.range.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_range(&mut self, v: ::std::string::String) {
+        self.range = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_range(&mut self) -> &mut ::std::string::String {
+        if self.range.is_none() {
+            self.range.set_default();
+        }
+        self.range.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_range(&mut self) -> ::std::string::String {
+        self.range.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_range(&self) -> &str {
+        match self.range.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    // optional uint64 count = 2;
+
+    pub fn clear_count(&mut self) {
+        self.count = ::std::option::Option::None;
+    }
+
+    pub fn has_count(&self) -> bool {
+        self.count.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_count(&mut self, v: u64) {
+        self.count = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_count(&self) -> u64 {
+        self.count.unwrap_or(0)
+    }
+}
+
+impl ::protobuf::Message for VMRange {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.range)?;
+                },
+                2 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_uint64()?;
+                    self.count = ::std::option::Option::Some(tmp);
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if let Some(ref v) = self.range.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
+        }
+        if let Some(v) = self.count {
+            my_size += ::protobuf::rt::value_size(2, v, ::protobuf::wire_format::WireTypeVarint);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(ref v) = self.range.as_ref() {
+            os.write_string(1, &v)?;
+        }
+        if let Some(v) = self.count {
+            os.write_uint64(2, v)?;
+        }
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        Self::descriptor_static()
+    }
+
+    fn new() -> VMRange {
+        VMRange::new()
+    }
+
+    fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "range",
+                    |m: &VMRange| { &m.range },
+                    |m: &mut VMRange| { &mut m.range },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
+                    "count",
+                    |m: &VMRange| { &m.count },
+                    |m: &mut VMRange| { &mut m.count },
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<VMRange>(
+                    "VMRange",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+
+    fn default_instance() -> &'static VMRange {
+        static mut instance: ::protobuf::lazy::Lazy<VMRange> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const VMRange,
+        };
+        unsafe {
+            instance.get(VMRange::new)
+        }
+    }
+}
+
+impl ::protobuf::Clear for VMRange {
+    fn clear(&mut self) {
+        self.clear_range();
+        self.clear_count();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for VMRange {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for VMRange {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -2430,6 +2947,7 @@ pub enum MetricType {
     SUMMARY = 2,
     UNTYPED = 3,
     HISTOGRAM = 4,
+    VMHISTOGRAM = 5,
 }
 
 impl ::protobuf::ProtobufEnum for MetricType {
@@ -2444,6 +2962,7 @@ impl ::protobuf::ProtobufEnum for MetricType {
             2 => ::std::option::Option::Some(MetricType::SUMMARY),
             3 => ::std::option::Option::Some(MetricType::UNTYPED),
             4 => ::std::option::Option::Some(MetricType::HISTOGRAM),
+            5 => ::std::option::Option::Some(MetricType::VMHISTOGRAM),
             _ => ::std::option::Option::None
         }
     }
@@ -2455,6 +2974,7 @@ impl ::protobuf::ProtobufEnum for MetricType {
             MetricType::SUMMARY,
             MetricType::UNTYPED,
             MetricType::HISTOGRAM,
+            MetricType::VMHISTOGRAM,
         ];
         values
     }
@@ -2476,42 +2996,195 @@ impl ::std::marker::Copy for MetricType {
 }
 
 impl ::protobuf::reflect::ProtobufValue for MetricType {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
     }
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\x11proto_model.proto\x12\x14io.prometheus.client\"0\n\tLabelPair\x12\
-    \x10\n\x04name\x18\x01\x20\x01(\tB\x02\x18\0\x12\x11\n\x05value\x18\x02\
-    \x20\x01(\tB\x02\x18\0\"\x1a\n\x05Gauge\x12\x11\n\x05value\x18\x01\x20\
-    \x01(\x01B\x02\x18\0\"\x1c\n\x07Counter\x12\x11\n\x05value\x18\x01\x20\
-    \x01(\x01B\x02\x18\0\"3\n\x08Quantile\x12\x14\n\x08quantile\x18\x01\x20\
-    \x01(\x01B\x02\x18\0\x12\x11\n\x05value\x18\x02\x20\x01(\x01B\x02\x18\0\
-    \"q\n\x07Summary\x12\x18\n\x0csample_count\x18\x01\x20\x01(\x04B\x02\x18\
-    \0\x12\x16\n\nsample_sum\x18\x02\x20\x01(\x01B\x02\x18\0\x124\n\x08quant\
-    ile\x18\x03\x20\x03(\x0b2\x1e.io.prometheus.client.QuantileB\x02\x18\0\"\
-    \x1c\n\x07Untyped\x12\x11\n\x05value\x18\x01\x20\x01(\x01B\x02\x18\0\"o\
-    \n\tHistogram\x12\x18\n\x0csample_count\x18\x01\x20\x01(\x04B\x02\x18\0\
-    \x12\x16\n\nsample_sum\x18\x02\x20\x01(\x01B\x02\x18\0\x120\n\x06bucket\
-    \x18\x03\x20\x03(\x0b2\x1c.io.prometheus.client.BucketB\x02\x18\0\"?\n\
-    \x06Bucket\x12\x1c\n\x10cumulative_count\x18\x01\x20\x01(\x04B\x02\x18\0\
-    \x12\x17\n\x0bupper_bound\x18\x02\x20\x01(\x01B\x02\x18\0\"\xda\x02\n\
-    \x06Metric\x122\n\x05label\x18\x01\x20\x03(\x0b2\x1f.io.prometheus.clien\
-    t.LabelPairB\x02\x18\0\x12.\n\x05gauge\x18\x02\x20\x01(\x0b2\x1b.io.prom\
-    etheus.client.GaugeB\x02\x18\0\x122\n\x07counter\x18\x03\x20\x01(\x0b2\
-    \x1d.io.prometheus.client.CounterB\x02\x18\0\x122\n\x07summary\x18\x04\
-    \x20\x01(\x0b2\x1d.io.prometheus.client.SummaryB\x02\x18\0\x122\n\x07unt\
-    yped\x18\x05\x20\x01(\x0b2\x1d.io.prometheus.client.UntypedB\x02\x18\0\
-    \x126\n\thistogram\x18\x07\x20\x01(\x0b2\x1f.io.prometheus.client.Histog\
-    ramB\x02\x18\0\x12\x18\n\x0ctimestamp_ms\x18\x06\x20\x01(\x03B\x02\x18\0\
-    \"\x98\x01\n\x0cMetricFamily\x12\x10\n\x04name\x18\x01\x20\x01(\tB\x02\
-    \x18\0\x12\x10\n\x04help\x18\x02\x20\x01(\tB\x02\x18\0\x122\n\x04type\
-    \x18\x03\x20\x01(\x0e2\x20.io.prometheus.client.MetricTypeB\x02\x18\0\
-    \x120\n\x06metric\x18\x04\x20\x03(\x0b2\x1c.io.prometheus.client.MetricB\
-    \x02\x18\0*Q\n\nMetricType\x12\x0b\n\x07COUNTER\x10\0\x12\t\n\x05GAUGE\
-    \x10\x01\x12\x0b\n\x07SUMMARY\x10\x02\x12\x0b\n\x07UNTYPED\x10\x03\x12\r\
-    \n\tHISTOGRAM\x10\x04\x1a\x02\x10\0B\0b\x06proto2\
+    \n\x17proto/proto_model.proto\x12\x14io.prometheus.client\"5\n\tLabelPai\
+    r\x12\x12\n\x04name\x18\x01\x20\x01(\tR\x04name\x12\x14\n\x05value\x18\
+    \x02\x20\x01(\tR\x05value\"\x1d\n\x05Gauge\x12\x14\n\x05value\x18\x01\
+    \x20\x01(\x01R\x05value\"\x1f\n\x07Counter\x12\x14\n\x05value\x18\x01\
+    \x20\x01(\x01R\x05value\"<\n\x08Quantile\x12\x1a\n\x08quantile\x18\x01\
+    \x20\x01(\x01R\x08quantile\x12\x14\n\x05value\x18\x02\x20\x01(\x01R\x05v\
+    alue\"\x87\x01\n\x07Summary\x12!\n\x0csample_count\x18\x01\x20\x01(\x04R\
+    \x0bsampleCount\x12\x1d\n\nsample_sum\x18\x02\x20\x01(\x01R\tsampleSum\
+    \x12:\n\x08quantile\x18\x03\x20\x03(\x0b2\x1e.io.prometheus.client.Quant\
+    ileR\x08quantile\"\x1f\n\x07Untyped\x12\x14\n\x05value\x18\x01\x20\x01(\
+    \x01R\x05value\"\x83\x01\n\tHistogram\x12!\n\x0csample_count\x18\x01\x20\
+    \x01(\x04R\x0bsampleCount\x12\x1d\n\nsample_sum\x18\x02\x20\x01(\x01R\ts\
+    ampleSum\x124\n\x06bucket\x18\x03\x20\x03(\x0b2\x1c.io.prometheus.client\
+    .BucketR\x06bucket\"T\n\x06Bucket\x12)\n\x10cumulative_count\x18\x01\x20\
+    \x01(\x04R\x0fcumulativeCount\x12\x1f\n\x0bupper_bound\x18\x02\x20\x01(\
+    \x01R\nupperBound\"\xc5\x03\n\x06Metric\x125\n\x05label\x18\x01\x20\x03(\
+    \x0b2\x1f.io.prometheus.client.LabelPairR\x05label\x121\n\x05gauge\x18\
+    \x02\x20\x01(\x0b2\x1b.io.prometheus.client.GaugeR\x05gauge\x127\n\x07co\
+    unter\x18\x03\x20\x01(\x0b2\x1d.io.prometheus.client.CounterR\x07counter\
+    \x127\n\x07summary\x18\x04\x20\x01(\x0b2\x1d.io.prometheus.client.Summar\
+    yR\x07summary\x127\n\x07untyped\x18\x05\x20\x01(\x0b2\x1d.io.prometheus.\
+    client.UntypedR\x07untyped\x12=\n\thistogram\x18\x07\x20\x01(\x0b2\x1f.i\
+    o.prometheus.client.HistogramR\thistogram\x12!\n\x0ctimestamp_ms\x18\x06\
+    \x20\x01(\x03R\x0btimestampMs\x12D\n\x0cvm_histogram\x18\x08\x20\x01(\
+    \x0b2!.io.prometheus.client.VMHistogramR\x0bvmHistogram\"\xa2\x01\n\x0cM\
+    etricFamily\x12\x12\n\x04name\x18\x01\x20\x01(\tR\x04name\x12\x12\n\x04h\
+    elp\x18\x02\x20\x01(\tR\x04help\x124\n\x04type\x18\x03\x20\x01(\x0e2\x20\
+    .io.prometheus.client.MetricTypeR\x04type\x124\n\x06metric\x18\x04\x20\
+    \x03(\x0b2\x1c.io.prometheus.client.MetricR\x06metric\"\x86\x01\n\x0bVMH\
+    istogram\x12!\n\x0csample_count\x18\x01\x20\x01(\x04R\x0bsampleCount\x12\
+    \x1d\n\nsample_sum\x18\x02\x20\x01(\x01R\tsampleSum\x125\n\x06ranges\x18\
+    \x03\x20\x03(\x0b2\x1d.io.prometheus.client.VMRangeR\x06ranges\"5\n\x07V\
+    MRange\x12\x14\n\x05range\x18\x01\x20\x01(\tR\x05range\x12\x14\n\x05coun\
+    t\x18\x02\x20\x01(\x04R\x05count*^\n\nMetricType\x12\x0b\n\x07COUNTER\
+    \x10\0\x12\t\n\x05GAUGE\x10\x01\x12\x0b\n\x07SUMMARY\x10\x02\x12\x0b\n\
+    \x07UNTYPED\x10\x03\x12\r\n\tHISTOGRAM\x10\x04\x12\x0f\n\x0bVMHISTOGRAM\
+    \x10\x05B\x16\n\x14io.prometheus.clientJ\xad\x1b\n\x06\x12\x04\r\0]\x01\
+    \n\xbc\x04\n\x01\x0c\x12\x03\r\0\x122\xb1\x04\x20Copyright\x202013\x20Pr\
+    ometheus\x20Team\n\x20Licensed\x20under\x20the\x20Apache\x20License,\x20\
+    Version\x202.0\x20(the\x20\"License\");\n\x20you\x20may\x20not\x20use\
+    \x20this\x20file\x20except\x20in\x20compliance\x20with\x20the\x20License\
+    .\n\x20You\x20may\x20obtain\x20a\x20copy\x20of\x20the\x20License\x20at\n\
+    \n\x20http://www.apache.org/licenses/LICENSE-2.0\n\n\x20Unless\x20requir\
+    ed\x20by\x20applicable\x20law\x20or\x20agreed\x20to\x20in\x20writing,\
+    \x20software\n\x20distributed\x20under\x20the\x20License\x20is\x20distri\
+    buted\x20on\x20an\x20\"AS\x20IS\"\x20BASIS,\n\x20WITHOUT\x20WARRANTIES\
+    \x20OR\x20CONDITIONS\x20OF\x20ANY\x20KIND,\x20either\x20express\x20or\
+    \x20implied.\n\x20See\x20the\x20License\x20for\x20the\x20specific\x20lan\
+    guage\x20governing\x20permissions\x20and\n\x20limitations\x20under\x20th\
+    e\x20License.\n\n\x08\n\x01\x02\x12\x03\x0f\0\x1d\n\x08\n\x01\x08\x12\
+    \x03\x10\0-\n\t\n\x02\x08\x01\x12\x03\x10\0-\n\n\n\x02\x04\0\x12\x04\x12\
+    \0\x15\x01\n\n\n\x03\x04\0\x01\x12\x03\x12\x08\x11\n\x0b\n\x04\x04\0\x02\
+    \0\x12\x03\x13\x02\x1c\n\x0c\n\x05\x04\0\x02\0\x04\x12\x03\x13\x02\n\n\
+    \x0c\n\x05\x04\0\x02\0\x05\x12\x03\x13\x0b\x11\n\x0c\n\x05\x04\0\x02\0\
+    \x01\x12\x03\x13\x12\x16\n\x0c\n\x05\x04\0\x02\0\x03\x12\x03\x13\x1a\x1b\
+    \n\x0b\n\x04\x04\0\x02\x01\x12\x03\x14\x02\x1c\n\x0c\n\x05\x04\0\x02\x01\
+    \x04\x12\x03\x14\x02\n\n\x0c\n\x05\x04\0\x02\x01\x05\x12\x03\x14\x0b\x11\
+    \n\x0c\n\x05\x04\0\x02\x01\x01\x12\x03\x14\x12\x17\n\x0c\n\x05\x04\0\x02\
+    \x01\x03\x12\x03\x14\x1a\x1b\n\n\n\x02\x05\0\x12\x04\x17\0\x1e\x01\n\n\n\
+    \x03\x05\0\x01\x12\x03\x17\x05\x0f\n\x0b\n\x04\x05\0\x02\0\x12\x03\x18\
+    \x02\x11\n\x0c\n\x05\x05\0\x02\0\x01\x12\x03\x18\x02\t\n\x0c\n\x05\x05\0\
+    \x02\0\x02\x12\x03\x18\x0f\x10\n\x0b\n\x04\x05\0\x02\x01\x12\x03\x19\x02\
+    \x11\n\x0c\n\x05\x05\0\x02\x01\x01\x12\x03\x19\x02\x07\n\x0c\n\x05\x05\0\
+    \x02\x01\x02\x12\x03\x19\x0f\x10\n\x0b\n\x04\x05\0\x02\x02\x12\x03\x1a\
+    \x02\x11\n\x0c\n\x05\x05\0\x02\x02\x01\x12\x03\x1a\x02\t\n\x0c\n\x05\x05\
+    \0\x02\x02\x02\x12\x03\x1a\x0f\x10\n\x0b\n\x04\x05\0\x02\x03\x12\x03\x1b\
+    \x02\x11\n\x0c\n\x05\x05\0\x02\x03\x01\x12\x03\x1b\x02\t\n\x0c\n\x05\x05\
+    \0\x02\x03\x02\x12\x03\x1b\x0f\x10\n\x0b\n\x04\x05\0\x02\x04\x12\x03\x1c\
+    \x02\x11\n\x0c\n\x05\x05\0\x02\x04\x01\x12\x03\x1c\x02\x0b\n\x0c\n\x05\
+    \x05\0\x02\x04\x02\x12\x03\x1c\x0f\x10\n\x0b\n\x04\x05\0\x02\x05\x12\x03\
+    \x1d\x02\x12\n\x0c\n\x05\x05\0\x02\x05\x01\x12\x03\x1d\x02\r\n\x0c\n\x05\
+    \x05\0\x02\x05\x02\x12\x03\x1d\x10\x11\n\n\n\x02\x04\x01\x12\x04\x20\0\"\
+    \x01\n\n\n\x03\x04\x01\x01\x12\x03\x20\x08\r\n\x0b\n\x04\x04\x01\x02\0\
+    \x12\x03!\x02\x1c\n\x0c\n\x05\x04\x01\x02\0\x04\x12\x03!\x02\n\n\x0c\n\
+    \x05\x04\x01\x02\0\x05\x12\x03!\x0b\x11\n\x0c\n\x05\x04\x01\x02\0\x01\
+    \x12\x03!\x12\x17\n\x0c\n\x05\x04\x01\x02\0\x03\x12\x03!\x1a\x1b\n\n\n\
+    \x02\x04\x02\x12\x04$\0&\x01\n\n\n\x03\x04\x02\x01\x12\x03$\x08\x0f\n\
+    \x0b\n\x04\x04\x02\x02\0\x12\x03%\x02\x1c\n\x0c\n\x05\x04\x02\x02\0\x04\
+    \x12\x03%\x02\n\n\x0c\n\x05\x04\x02\x02\0\x05\x12\x03%\x0b\x11\n\x0c\n\
+    \x05\x04\x02\x02\0\x01\x12\x03%\x12\x17\n\x0c\n\x05\x04\x02\x02\0\x03\
+    \x12\x03%\x1a\x1b\n\n\n\x02\x04\x03\x12\x04(\0+\x01\n\n\n\x03\x04\x03\
+    \x01\x12\x03(\x08\x10\n\x0b\n\x04\x04\x03\x02\0\x12\x03)\x02\x1f\n\x0c\n\
+    \x05\x04\x03\x02\0\x04\x12\x03)\x02\n\n\x0c\n\x05\x04\x03\x02\0\x05\x12\
+    \x03)\x0b\x11\n\x0c\n\x05\x04\x03\x02\0\x01\x12\x03)\x12\x1a\n\x0c\n\x05\
+    \x04\x03\x02\0\x03\x12\x03)\x1d\x1e\n\x0b\n\x04\x04\x03\x02\x01\x12\x03*\
+    \x02\x1f\n\x0c\n\x05\x04\x03\x02\x01\x04\x12\x03*\x02\n\n\x0c\n\x05\x04\
+    \x03\x02\x01\x05\x12\x03*\x0b\x11\n\x0c\n\x05\x04\x03\x02\x01\x01\x12\
+    \x03*\x12\x17\n\x0c\n\x05\x04\x03\x02\x01\x03\x12\x03*\x1d\x1e\n\n\n\x02\
+    \x04\x04\x12\x04-\01\x01\n\n\n\x03\x04\x04\x01\x12\x03-\x08\x0f\n\x0b\n\
+    \x04\x04\x04\x02\0\x12\x03.\x02%\n\x0c\n\x05\x04\x04\x02\0\x04\x12\x03.\
+    \x02\n\n\x0c\n\x05\x04\x04\x02\0\x05\x12\x03.\x0b\x11\n\x0c\n\x05\x04\
+    \x04\x02\0\x01\x12\x03.\x14\x20\n\x0c\n\x05\x04\x04\x02\0\x03\x12\x03.#$\
+    \n\x0b\n\x04\x04\x04\x02\x01\x12\x03/\x02%\n\x0c\n\x05\x04\x04\x02\x01\
+    \x04\x12\x03/\x02\n\n\x0c\n\x05\x04\x04\x02\x01\x05\x12\x03/\x0b\x11\n\
+    \x0c\n\x05\x04\x04\x02\x01\x01\x12\x03/\x14\x1e\n\x0c\n\x05\x04\x04\x02\
+    \x01\x03\x12\x03/#$\n\x0b\n\x04\x04\x04\x02\x02\x12\x030\x02%\n\x0c\n\
+    \x05\x04\x04\x02\x02\x04\x12\x030\x02\n\n\x0c\n\x05\x04\x04\x02\x02\x06\
+    \x12\x030\x0b\x13\n\x0c\n\x05\x04\x04\x02\x02\x01\x12\x030\x14\x1c\n\x0c\
+    \n\x05\x04\x04\x02\x02\x03\x12\x030#$\n\n\n\x02\x04\x05\x12\x043\05\x01\
+    \n\n\n\x03\x04\x05\x01\x12\x033\x08\x0f\n\x0b\n\x04\x04\x05\x02\0\x12\
+    \x034\x02\x1c\n\x0c\n\x05\x04\x05\x02\0\x04\x12\x034\x02\n\n\x0c\n\x05\
+    \x04\x05\x02\0\x05\x12\x034\x0b\x11\n\x0c\n\x05\x04\x05\x02\0\x01\x12\
+    \x034\x12\x17\n\x0c\n\x05\x04\x05\x02\0\x03\x12\x034\x1a\x1b\n\n\n\x02\
+    \x04\x06\x12\x047\0;\x01\n\n\n\x03\x04\x06\x01\x12\x037\x08\x11\n\x0b\n\
+    \x04\x04\x06\x02\0\x12\x038\x02#\n\x0c\n\x05\x04\x06\x02\0\x04\x12\x038\
+    \x02\n\n\x0c\n\x05\x04\x06\x02\0\x05\x12\x038\x0b\x11\n\x0c\n\x05\x04\
+    \x06\x02\0\x01\x12\x038\x12\x1e\n\x0c\n\x05\x04\x06\x02\0\x03\x12\x038!\
+    \"\n\x0b\n\x04\x04\x06\x02\x01\x12\x039\x02#\n\x0c\n\x05\x04\x06\x02\x01\
+    \x04\x12\x039\x02\n\n\x0c\n\x05\x04\x06\x02\x01\x05\x12\x039\x0b\x11\n\
+    \x0c\n\x05\x04\x06\x02\x01\x01\x12\x039\x12\x1c\n\x0c\n\x05\x04\x06\x02\
+    \x01\x03\x12\x039!\"\nS\n\x04\x04\x06\x02\x02\x12\x03:\x02#\"F\x20Ordere\
+    d\x20in\x20increasing\x20order\x20of\x20upper_bound,\x20+Inf\x20bucket\
+    \x20is\x20optional.\n\n\x0c\n\x05\x04\x06\x02\x02\x04\x12\x03:\x02\n\n\
+    \x0c\n\x05\x04\x06\x02\x02\x06\x12\x03:\x0b\x11\n\x0c\n\x05\x04\x06\x02\
+    \x02\x01\x12\x03:\x12\x18\n\x0c\n\x05\x04\x06\x02\x02\x03\x12\x03:!\"\n\
+    \n\n\x02\x04\x07\x12\x04=\0@\x01\n\n\n\x03\x04\x07\x01\x12\x03=\x08\x0e\
+    \n.\n\x04\x04\x07\x02\0\x12\x03>\x02'\"!\x20Cumulative\x20in\x20increasi\
+    ng\x20order.\n\n\x0c\n\x05\x04\x07\x02\0\x04\x12\x03>\x02\n\n\x0c\n\x05\
+    \x04\x07\x02\0\x05\x12\x03>\x0b\x11\n\x0c\n\x05\x04\x07\x02\0\x01\x12\
+    \x03>\x12\"\n\x0c\n\x05\x04\x07\x02\0\x03\x12\x03>%&\n\x19\n\x04\x04\x07\
+    \x02\x01\x12\x03?\x02\"\"\x0c\x20Inclusive.\n\n\x0c\n\x05\x04\x07\x02\
+    \x01\x04\x12\x03?\x02\n\n\x0c\n\x05\x04\x07\x02\x01\x05\x12\x03?\x0b\x11\
+    \n\x0c\n\x05\x04\x07\x02\x01\x01\x12\x03?\x12\x1d\n\x0c\n\x05\x04\x07\
+    \x02\x01\x03\x12\x03?\x20!\n\n\n\x02\x04\x08\x12\x04B\0K\x01\n\n\n\x03\
+    \x04\x08\x01\x12\x03B\x08\x0e\n\x0b\n\x04\x04\x08\x02\0\x12\x03C\x02&\n\
+    \x0c\n\x05\x04\x08\x02\0\x04\x12\x03C\x02\n\n\x0c\n\x05\x04\x08\x02\0\
+    \x06\x12\x03C\x0b\x14\n\x0c\n\x05\x04\x08\x02\0\x01\x12\x03C\x15\x1a\n\
+    \x0c\n\x05\x04\x08\x02\0\x03\x12\x03C$%\n\x0b\n\x04\x04\x08\x02\x01\x12\
+    \x03D\x02&\n\x0c\n\x05\x04\x08\x02\x01\x04\x12\x03D\x02\n\n\x0c\n\x05\
+    \x04\x08\x02\x01\x06\x12\x03D\x0b\x10\n\x0c\n\x05\x04\x08\x02\x01\x01\
+    \x12\x03D\x15\x1a\n\x0c\n\x05\x04\x08\x02\x01\x03\x12\x03D$%\n\x0b\n\x04\
+    \x04\x08\x02\x02\x12\x03E\x02&\n\x0c\n\x05\x04\x08\x02\x02\x04\x12\x03E\
+    \x02\n\n\x0c\n\x05\x04\x08\x02\x02\x06\x12\x03E\x0b\x12\n\x0c\n\x05\x04\
+    \x08\x02\x02\x01\x12\x03E\x15\x1c\n\x0c\n\x05\x04\x08\x02\x02\x03\x12\
+    \x03E$%\n\x0b\n\x04\x04\x08\x02\x03\x12\x03F\x02&\n\x0c\n\x05\x04\x08\
+    \x02\x03\x04\x12\x03F\x02\n\n\x0c\n\x05\x04\x08\x02\x03\x06\x12\x03F\x0b\
+    \x12\n\x0c\n\x05\x04\x08\x02\x03\x01\x12\x03F\x15\x1c\n\x0c\n\x05\x04\
+    \x08\x02\x03\x03\x12\x03F$%\n\x0b\n\x04\x04\x08\x02\x04\x12\x03G\x02&\n\
+    \x0c\n\x05\x04\x08\x02\x04\x04\x12\x03G\x02\n\n\x0c\n\x05\x04\x08\x02\
+    \x04\x06\x12\x03G\x0b\x12\n\x0c\n\x05\x04\x08\x02\x04\x01\x12\x03G\x15\
+    \x1c\n\x0c\n\x05\x04\x08\x02\x04\x03\x12\x03G$%\n\x0b\n\x04\x04\x08\x02\
+    \x05\x12\x03H\x02&\n\x0c\n\x05\x04\x08\x02\x05\x04\x12\x03H\x02\n\n\x0c\
+    \n\x05\x04\x08\x02\x05\x06\x12\x03H\x0b\x14\n\x0c\n\x05\x04\x08\x02\x05\
+    \x01\x12\x03H\x15\x1e\n\x0c\n\x05\x04\x08\x02\x05\x03\x12\x03H$%\n\x0b\n\
+    \x04\x04\x08\x02\x06\x12\x03I\x02&\n\x0c\n\x05\x04\x08\x02\x06\x04\x12\
+    \x03I\x02\n\n\x0c\n\x05\x04\x08\x02\x06\x05\x12\x03I\x0b\x10\n\x0c\n\x05\
+    \x04\x08\x02\x06\x01\x12\x03I\x15!\n\x0c\n\x05\x04\x08\x02\x06\x03\x12\
+    \x03I$%\n\x0b\n\x04\x04\x08\x02\x07\x12\x03J\x02(\n\x0c\n\x05\x04\x08\
+    \x02\x07\x04\x12\x03J\x02\n\n\x0c\n\x05\x04\x08\x02\x07\x06\x12\x03J\x0b\
+    \x16\n\x0c\n\x05\x04\x08\x02\x07\x01\x12\x03J\x17#\n\x0c\n\x05\x04\x08\
+    \x02\x07\x03\x12\x03J&'\n\n\n\x02\x04\t\x12\x04M\0R\x01\n\n\n\x03\x04\t\
+    \x01\x12\x03M\x08\x14\n\x0b\n\x04\x04\t\x02\0\x12\x03N\x02!\n\x0c\n\x05\
+    \x04\t\x02\0\x04\x12\x03N\x02\n\n\x0c\n\x05\x04\t\x02\0\x05\x12\x03N\x0b\
+    \x11\n\x0c\n\x05\x04\t\x02\0\x01\x12\x03N\x16\x1a\n\x0c\n\x05\x04\t\x02\
+    \0\x03\x12\x03N\x1f\x20\n\x0b\n\x04\x04\t\x02\x01\x12\x03O\x02!\n\x0c\n\
+    \x05\x04\t\x02\x01\x04\x12\x03O\x02\n\n\x0c\n\x05\x04\t\x02\x01\x05\x12\
+    \x03O\x0b\x11\n\x0c\n\x05\x04\t\x02\x01\x01\x12\x03O\x16\x1a\n\x0c\n\x05\
+    \x04\t\x02\x01\x03\x12\x03O\x1f\x20\n\x0b\n\x04\x04\t\x02\x02\x12\x03P\
+    \x02!\n\x0c\n\x05\x04\t\x02\x02\x04\x12\x03P\x02\n\n\x0c\n\x05\x04\t\x02\
+    \x02\x06\x12\x03P\x0b\x15\n\x0c\n\x05\x04\t\x02\x02\x01\x12\x03P\x16\x1a\
+    \n\x0c\n\x05\x04\t\x02\x02\x03\x12\x03P\x1f\x20\n\x0b\n\x04\x04\t\x02\
+    \x03\x12\x03Q\x02!\n\x0c\n\x05\x04\t\x02\x03\x04\x12\x03Q\x02\n\n\x0c\n\
+    \x05\x04\t\x02\x03\x06\x12\x03Q\x0b\x11\n\x0c\n\x05\x04\t\x02\x03\x01\
+    \x12\x03Q\x16\x1c\n\x0c\n\x05\x04\t\x02\x03\x03\x12\x03Q\x1f\x20\n\n\n\
+    \x02\x04\n\x12\x04T\0X\x01\n\n\n\x03\x04\n\x01\x12\x03T\x08\x13\n\x0b\n\
+    \x04\x04\n\x02\0\x12\x03U\x02#\n\x0c\n\x05\x04\n\x02\0\x04\x12\x03U\x02\
+    \n\n\x0c\n\x05\x04\n\x02\0\x05\x12\x03U\x0b\x11\n\x0c\n\x05\x04\n\x02\0\
+    \x01\x12\x03U\x12\x1e\n\x0c\n\x05\x04\n\x02\0\x03\x12\x03U!\"\n\x0b\n\
+    \x04\x04\n\x02\x01\x12\x03V\x02!\n\x0c\n\x05\x04\n\x02\x01\x04\x12\x03V\
+    \x02\n\n\x0c\n\x05\x04\n\x02\x01\x05\x12\x03V\x0b\x11\n\x0c\n\x05\x04\n\
+    \x02\x01\x01\x12\x03V\x12\x1c\n\x0c\n\x05\x04\n\x02\x01\x03\x12\x03V\x1f\
+    \x20\n\x0b\n\x04\x04\n\x02\x02\x12\x03W\x02\x1e\n\x0c\n\x05\x04\n\x02\
+    \x02\x04\x12\x03W\x02\n\n\x0c\n\x05\x04\n\x02\x02\x06\x12\x03W\x0b\x12\n\
+    \x0c\n\x05\x04\n\x02\x02\x01\x12\x03W\x13\x19\n\x0c\n\x05\x04\n\x02\x02\
+    \x03\x12\x03W\x1c\x1d\n\n\n\x02\x04\x0b\x12\x04Z\0]\x01\n\n\n\x03\x04\
+    \x0b\x01\x12\x03Z\x08\x0f\n\x0b\n\x04\x04\x0b\x02\0\x12\x03[\x02\x1c\n\
+    \x0c\n\x05\x04\x0b\x02\0\x04\x12\x03[\x02\n\n\x0c\n\x05\x04\x0b\x02\0\
+    \x05\x12\x03[\x0b\x11\n\x0c\n\x05\x04\x0b\x02\0\x01\x12\x03[\x12\x17\n\
+    \x0c\n\x05\x04\x0b\x02\0\x03\x12\x03[\x1a\x1b\n\x0b\n\x04\x04\x0b\x02\
+    \x01\x12\x03\\\x02\x1c\n\x0c\n\x05\x04\x0b\x02\x01\x04\x12\x03\\\x02\n\n\
+    \x0c\n\x05\x04\x0b\x02\x01\x05\x12\x03\\\x0b\x11\n\x0c\n\x05\x04\x0b\x02\
+    \x01\x01\x12\x03\\\x12\x17\n\x0c\n\x05\x04\x0b\x02\x01\x03\x12\x03\\\x1a\
+    \x1b\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/src/atomic64.rs
+++ b/src/atomic64.rs
@@ -71,7 +71,7 @@ pub trait Atomic: Send + Sync {
 }
 
 /// A atomic float.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct AtomicF64 {
     inner: StdAtomicU64,
 }
@@ -172,7 +172,7 @@ impl Atomic for AtomicI64 {
 }
 
 /// A atomic unsigned integer.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct AtomicU64 {
     inner: StdAtomicU64,
 }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -29,6 +29,7 @@ pub const DEFAULT_BUCKETS: &[f64; 11] = &[
 /// Used for the label that defines the upper bound of a
 /// bucket of a histogram ("le" -> "less or equal").
 pub const BUCKET_LABEL: &str = "le";
+pub const VMRANGE_LABEL: &str = "vmrange";
 
 #[inline]
 fn check_bucket_label(label: &str) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,6 @@ This library supports four features:
 )]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
-#![feature(once_cell)]
 
 /// Protocol buffers format of metrics.
 #[cfg(feature = "protobuf")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,3 +230,4 @@ pub use self::push::{
 };
 pub use self::registry::Registry;
 pub use self::registry::{default_registry, gather, register, unregister};
+pub use self::vmhistogram::{VMHistogram, VMHistogramVec};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ This library supports four features:
 )]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![feature(once_cell)]
 
 /// Protocol buffers format of metrics.
 #[cfg(feature = "protobuf")]
@@ -164,6 +165,7 @@ mod push;
 mod registry;
 mod value;
 mod vec;
+mod vmhistogram;
 
 // Public for generated code.
 #[doc(hidden)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1144,3 +1144,58 @@ fn test_register_histogram_vec_with_registry_trailing_comma() {
     );
     assert!(histogram_vec.is_ok());
 }
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
+macro_rules! register_vmhistogram {
+    ($NAME:expr, $HELP:expr $(,)?) => {
+        register_vmhistogram!(opts!($NAME, $HELP))
+    };
+    ($HOPTS:expr $(,)?) => {{
+        let histogram = $crate::VMHistogram::with_opts($HOPTS).unwrap();
+        $crate::register(Box::new(histogram.clone())).map(|_| histogram)
+    }};
+}
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
+macro_rules! register_vmhistogram_vec {
+    ($HOPTS:expr, $LABELS_NAMES:expr $(,)?) => {{
+        let histogram_vec = $crate::VMHistogramVec::new($HOPTS, $LABELS_NAMES).unwrap();
+        $crate::register(Box::new(histogram_vec.clone())).map(|_| histogram_vec)
+    }};
+
+    ($NAME:expr, $HELP:expr, $LABELS_NAMES:expr $(,)?) => {{
+        register_vmhistogram_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
+    }};
+}
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
+macro_rules! register_vmhistogram_with_registry {
+    ($NAME:expr, $HELP:expr, $REGISTRY:expr $(,)?) => {
+        register_vmhistogram_with_registry!(opts!($NAME, $HELP), $REGISTRY)
+    };
+
+    ($HOPTS:expr, $REGISTRY:expr $(,)?) => {{
+        let histogram = $crate::Histogram::with_opts($HOPTS).unwrap();
+        $REGISTRY
+            .register(Box::new(histogram.clone()))
+            .map(|_| histogram)
+    }};
+}
+
+#[allow(missing_docs)]
+#[macro_export(local_inner_macros)]
+macro_rules! register_vmhistogram_vec_with_registry {
+    ($HOPTS:expr, $LABELS_NAMES:expr, $REGISTRY:expr $(,)?) => {{
+        let histogram_vec = $crate::VMHistogramVec::new($HOPTS, $LABELS_NAMES).unwrap();
+        $REGISTRY
+            .register(Box::new(histogram_vec.clone()))
+            .map(|_| histogram_vec)
+    }};
+
+    ($NAME:expr, $HELP:expr, $LABELS_NAMES:expr, $REGISTRY:expr $(,)?) => {{
+        register_vmhistogram_vec_with_registry!(opts!($NAME, $HELP), $LABELS_NAMES, $REGISTRY)
+    }};
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1145,7 +1145,22 @@ fn test_register_histogram_vec_with_registry_trailing_comma() {
     assert!(histogram_vec.is_ok());
 }
 
-#[allow(missing_docs)]
+/// Create a [`VMHistogram`][crate::VMHistogram] and registers to default registry.
+///
+/// # Examples
+///
+/// ```
+/// # use prometheus::{opts, register_vmhistogram};
+/// # fn main() {
+/// let opts = opts!("test_macro_histogram", "help");
+/// let res1 = register_vmhistogram!(opts);
+/// assert!(res1.is_ok());
+///
+/// let res2 = register_vmhistogram!("test_macro_histogram_2", "help");
+/// assert!(res2.is_ok());
+///
+/// # }
+/// ```
 #[macro_export(local_inner_macros)]
 macro_rules! register_vmhistogram {
     ($NAME:expr, $HELP:expr $(,)?) => {
@@ -1157,7 +1172,23 @@ macro_rules! register_vmhistogram {
     }};
 }
 
-#[allow(missing_docs)]
+/// Create a [`VMHistogramVec`][crate::VMHistogramVec] and registers to default registry.
+///
+/// # Examples
+///
+/// ```
+/// # use prometheus::{opts, register_vmhistogram_vec};
+/// # fn main() {
+/// let opts = opts!("test_macro_histogram_vec_1", "help");
+/// let histogram_vec = register_vmhistogram_vec!(opts, &["a", "b"]);
+/// assert!(histogram_vec.is_ok());
+///
+/// let histogram_vec =
+///     register_vmhistogram_vec!("test_macro_histogram_vec_2", "help", &["a", "b"]);
+/// assert!(histogram_vec.is_ok());
+///
+/// # }
+/// ```
 #[macro_export(local_inner_macros)]
 macro_rules! register_vmhistogram_vec {
     ($HOPTS:expr, $LABELS_NAMES:expr $(,)?) => {{
@@ -1170,7 +1201,28 @@ macro_rules! register_vmhistogram_vec {
     }};
 }
 
-#[allow(missing_docs)]
+/// Create a [`VMHistogram`][crate::VMHistogram] and registers to a custom registry.
+///
+/// # Examples
+///
+/// ```
+/// # use prometheus::{register_vmhistogram_with_registry, opts};
+/// # use prometheus::Registry;
+/// # use std::collections::HashMap;
+/// # fn main() {
+/// let mut labels = HashMap::new();
+/// labels.insert("mykey".to_string(), "myvalue".to_string());
+/// let custom_registry = Registry::new_custom(Some("myprefix".to_string()), Some(labels)).unwrap();
+///
+/// let opts = opts!("test_macro_histogram", "help");
+/// let res1 = register_vmhistogram_with_registry!(opts, custom_registry);
+/// assert!(res1.is_ok());
+///
+/// let res2 = register_vmhistogram_with_registry!("test_macro_histogram_2", "help", custom_registry);
+/// assert!(res2.is_ok());
+///
+/// # }
+/// ```
 #[macro_export(local_inner_macros)]
 macro_rules! register_vmhistogram_with_registry {
     ($NAME:expr, $HELP:expr, $REGISTRY:expr $(,)?) => {
@@ -1185,7 +1237,29 @@ macro_rules! register_vmhistogram_with_registry {
     }};
 }
 
-#[allow(missing_docs)]
+/// Create a [`VMHistogramVec`][crate::VMHistogramVec] and registers to default registry.
+///
+/// # Examples
+///
+/// ```
+/// # use prometheus::{register_vmhistogram_vec_with_registry, opts};
+/// # use prometheus::Registry;
+/// # use std::collections::HashMap;
+/// # fn main() {
+/// let mut labels = HashMap::new();
+/// labels.insert("mykey".to_string(), "myvalue".to_string());
+/// let custom_registry = Registry::new_custom(Some("myprefix".to_string()), Some(labels)).unwrap();
+///
+/// let opts = opts!("test_macro_histogram_vec_1", "help");
+/// let histogram_vec = register_vmhistogram_vec_with_registry!(opts, &["a", "b"], custom_registry);
+/// assert!(histogram_vec.is_ok());
+///
+/// let histogram_vec =
+///     register_vmhistogram_vec_with_registry!("test_macro_histogram_vec_2", "help", &["a", "b"], custom_registry);
+/// assert!(histogram_vec.is_ok());
+///
+/// # }
+/// ```
 #[macro_export(local_inner_macros)]
 macro_rules! register_vmhistogram_vec_with_registry {
     ($HOPTS:expr, $LABELS_NAMES:expr, $REGISTRY:expr $(,)?) => {{

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1178,7 +1178,7 @@ macro_rules! register_vmhistogram_with_registry {
     };
 
     ($HOPTS:expr, $REGISTRY:expr $(,)?) => {{
-        let histogram = $crate::Histogram::with_opts($HOPTS).unwrap();
+        let histogram = $crate::VMHistogram::with_opts($HOPTS).unwrap();
         $REGISTRY
             .register(Box::new(histogram.clone()))
             .map(|_| histogram)

--- a/src/vmhistogram.rs
+++ b/src/vmhistogram.rs
@@ -1,0 +1,196 @@
+use std::{
+    mem::MaybeUninit,
+    sync::{Arc, LazyLock},
+};
+
+use parking_lot::Mutex;
+
+use crate::{
+    core::{Collector, Desc, Describer, Metric, MetricVec, MetricVecBuilder},
+    proto::{self, LabelPair},
+    value::make_label_pairs,
+    Opts,
+};
+
+const E_10_MIN: i64 = -9;
+const E_10_MAX: i64 = 18;
+const BUCKETS_PER_DECIMAL: usize = 18;
+const DECIMAL_BUCKETS_COUNT: usize = (E_10_MAX - E_10_MIN) as usize;
+const BUCKETS_COUNT: usize = DECIMAL_BUCKETS_COUNT * BUCKETS_PER_DECIMAL;
+static BUCKET_MULTIPLIER: LazyLock<f64> =
+    LazyLock::new(|| 10f64.powf(1.0f64 / BUCKETS_PER_DECIMAL as f64));
+static LOWER_BUCKET_RANGE: LazyLock<String> =
+    LazyLock::new(|| format!("0...{:.3e}", 10f64.powi(E_10_MIN as i32)));
+static UPPER_BUCKET_RANGE: LazyLock<String> =
+    LazyLock::new(|| format!("{:.3e}...+Inf", 10f64.powi(E_10_MAX as i32)));
+static BUCKET_RANGES: LazyLock<[String; BUCKETS_COUNT]> = LazyLock::new(|| {
+    // SAFETY: The `assume_init` is safe because the type we are claiming to
+    // have initialized here is a bunch of `MaybeUninit`s, which do not require
+    // initialization.
+    let mut ranges: [MaybeUninit<String>; BUCKETS_COUNT] =
+        unsafe { MaybeUninit::uninit().assume_init() };
+    let mut v = 10f64.powi(E_10_MIN as i32);
+    let mut start = format!("{:.3e}", v);
+    for elem in &mut ranges {
+        v = v * *BUCKET_MULTIPLIER;
+        let end = format!("{:.3e}", v);
+        elem.write(format!("{}...{}", start, end));
+        start = end;
+    }
+    // SAFETY: We've iterated over the full array and initialized every element with
+    // a `String`.
+    unsafe { std::mem::transmute(ranges) }
+});
+
+#[derive(Default)]
+struct Inner {
+    decimal_buckets: [Option<[u64; BUCKETS_PER_DECIMAL as usize]>; DECIMAL_BUCKETS_COUNT as usize],
+    lower: u64,
+    upper: u64,
+    sum: f64,
+}
+
+#[allow(missing_debug_implementations)]
+#[derive(Clone)]
+pub struct VMHistogram {
+    inner: Arc<Mutex<Inner>>,
+    desc: Arc<Desc>,
+    label_pairs: Arc<Vec<LabelPair>>,
+}
+
+impl VMHistogram {
+    pub fn with_opts(opts: &Opts) -> crate::Result<Self> {
+        VMHistogram::with_opts_and_label_values(opts, &[])
+    }
+
+    pub fn with_opts_and_label_values(opts: &Opts, label_values: &[&str]) -> crate::Result<Self> {
+        let desc = opts.describe()?;
+
+        let label_pairs = make_label_pairs(&desc, label_values)?;
+        Ok(VMHistogram {
+            inner: Arc::new(Mutex::new(Inner::default())),
+            desc: Arc::new(desc),
+            label_pairs: Arc::new(label_pairs),
+        })
+    }
+
+    pub fn observe(&self, value: f64) {
+        if value.is_nan() || value.is_sign_negative() {
+            return;
+        }
+        let bucket_idx = (value.log10() - E_10_MIN as f64) * BUCKETS_PER_DECIMAL as f64;
+        let mut inner = self.inner.lock();
+        inner.sum += value;
+        if bucket_idx.is_sign_negative() {
+            inner.lower += 1;
+        } else if bucket_idx as usize >= BUCKETS_COUNT {
+            inner.upper += 1;
+        } else {
+            let mut idx = bucket_idx as usize;
+            if idx as f64 == bucket_idx && idx > 0 {
+                // Edge case for 10^n values, which must go to the lower bucket
+                // according to Prometheus logic for `le`-based histograms.
+                idx = idx - 1;
+            }
+            let decimal_bucket_idx = idx / BUCKETS_PER_DECIMAL;
+            let offset = idx % BUCKETS_PER_DECIMAL;
+            let bucket = &mut inner.decimal_buckets[decimal_bucket_idx];
+            bucket.get_or_insert_with(Default::default)[offset] += 1;
+        }
+    }
+
+    fn proto(&self) -> proto::VMHistogram {
+        let mut h = proto::VMHistogram::default();
+        let mut count_total = 0;
+
+        let inner = self.inner.lock();
+        let sum_total = inner.sum;
+        inner.visit_nonzero_buckets(|vmrange, count| {
+            let mut range_proto = proto::VMRange::default();
+            range_proto.set_range(vmrange.to_owned());
+            range_proto.set_count(count);
+            h.mut_ranges().push(range_proto);
+            count_total += count;
+        });
+        h.set_sample_count(count_total);
+        h.set_sample_sum(sum_total);
+        h
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct VMHistogramVecBuilder {}
+
+impl MetricVecBuilder for VMHistogramVecBuilder {
+    type M = VMHistogram;
+    type P = Opts;
+
+    fn build(&self, opts: &Self::P, vals: &[&str]) -> crate::Result<Self::M> {
+        VMHistogram::with_opts_and_label_values(opts, vals)
+    }
+}
+
+impl Metric for VMHistogram {
+    fn metric(&self) -> crate::proto::Metric {
+        let mut m = proto::Metric::default();
+        m.set_label((*self.label_pairs).clone().into());
+
+        let h = self.proto();
+        m.set_vm_histogram(h);
+        m
+    }
+}
+
+impl Collector for VMHistogram {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&self.desc]
+    }
+
+    fn collect(&self) -> Vec<proto::MetricFamily> {
+        let mut m = proto::MetricFamily::default();
+        m.set_name(self.desc.fq_name.clone());
+        m.set_help(self.desc.help.clone());
+        m.set_field_type(proto::MetricType::VMHISTOGRAM);
+        m.set_metric(vec![self.metric()].into());
+        vec![m]
+    }
+}
+
+pub type VMHistogramVec = MetricVec<VMHistogramVecBuilder>;
+
+impl VMHistogramVec {
+    #[allow(missing_docs)]
+    pub fn new(opts: Opts, label_names: &[&str]) -> crate::Result<VMHistogramVec> {
+        let variable_names = label_names.iter().map(|s| (*s).to_owned()).collect();
+        let opts = opts.variable_labels(variable_names);
+        let metric_vec =
+            MetricVec::create(proto::MetricType::HISTOGRAM, VMHistogramVecBuilder {}, opts)?;
+
+        Ok(metric_vec)
+    }
+}
+
+impl Inner {
+    pub fn visit_nonzero_buckets<F>(&self, mut visitor: F)
+    where
+        F: FnMut(&str, u64),
+    {
+        if self.lower > 0 {
+            visitor(&LOWER_BUCKET_RANGE, self.lower);
+        }
+        for (decimal_bucket_idx, bucket) in self.decimal_buckets.iter().enumerate() {
+            if let Some(buckets) = bucket {
+                for (offset, count) in buckets.iter().enumerate() {
+                    if *count > 0 {
+                        let bucket_idx = decimal_bucket_idx * BUCKETS_PER_DECIMAL + offset;
+                        let vmrange = BUCKET_RANGES[bucket_idx].as_str();
+                        visitor(vmrange, *count);
+                    }
+                }
+            }
+        }
+        if self.upper > 0 {
+            visitor(&UPPER_BUCKET_RANGE, self.upper)
+        }
+    }
+}

--- a/src/vmhistogram.rs
+++ b/src/vmhistogram.rs
@@ -1,3 +1,27 @@
+//! Rust reimplementation of https://github.com/VictoriaMetrics/metrics/blob/ae1e9d8058de94e5622ccee515ece7992d67d209/histogram.go
+// Originally distributed under the following license:
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 VictoriaMetrics
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 use std::{
     mem::MaybeUninit,
     sync::{Arc, LazyLock},
@@ -12,17 +36,17 @@ use crate::{
     Opts,
 };
 
-const E_10_MIN: i64 = -9;
-const E_10_MAX: i64 = 18;
+const E_10_MIN: i32 = -9;
+const E_10_MAX: i32 = 18;
 const BUCKETS_PER_DECIMAL: usize = 18;
 const DECIMAL_BUCKETS_COUNT: usize = (E_10_MAX - E_10_MIN) as usize;
 const BUCKETS_COUNT: usize = DECIMAL_BUCKETS_COUNT * BUCKETS_PER_DECIMAL;
 static BUCKET_MULTIPLIER: LazyLock<f64> =
     LazyLock::new(|| 10f64.powf(1.0f64 / BUCKETS_PER_DECIMAL as f64));
 static LOWER_BUCKET_RANGE: LazyLock<String> =
-    LazyLock::new(|| format!("0...{:.3e}", 10f64.powi(E_10_MIN as i32)));
+    LazyLock::new(|| format!("0...{:.3e}", 10f64.powi(E_10_MIN)));
 static UPPER_BUCKET_RANGE: LazyLock<String> =
-    LazyLock::new(|| format!("{:.3e}...+Inf", 10f64.powi(E_10_MAX as i32)));
+    LazyLock::new(|| format!("{:.3e}...+Inf", 10f64.powi(E_10_MAX)));
 static BUCKET_RANGES: LazyLock<[String; BUCKETS_COUNT]> = LazyLock::new(|| {
     // SAFETY: The `assume_init` is safe because the type we are claiming to
     // have initialized here is a bunch of `MaybeUninit`s, which do not require
@@ -50,7 +74,34 @@ struct Inner {
     sum: f64,
 }
 
-#[allow(missing_debug_implementations, missing_docs)]
+/// Histogram is a histogram for non-negative values with automatically created buckets.
+///
+/// See https://medium.com/@valyala/improving-histogram-usability-for-prometheus-and-grafana-bc7e5df0e350
+///
+/// Each bucket contains a counter for values in the given range.
+/// Each non-empty bucket is exposed via the following metric:
+///
+///	<metric_name>_bucket{<optional_tags>,vmrange="<start>...<end>"} <counter>
+///
+/// Where:
+///
+///   - <metric_name> is the metric name passed to NewHistogram
+///   - <optional_tags> is optional tags for the <metric_name>, which are passed to NewHistogram
+///   - <start> and <end> - start and end values for the given bucket
+///   - <counter> - the number of hits to the given bucket during Update* calls
+///
+/// Histogram buckets can be converted to Prometheus-like buckets with `le` labels
+/// with `prometheus_buckets(<metric_name>_bucket)` function from PromQL extensions in VictoriaMetrics.
+/// (see https://github.com/VictoriaMetrics/VictoriaMetrics/wiki/MetricsQL ):
+///
+///	prometheus_buckets(request_duration_bucket)
+///
+/// Time series produced by the Histogram have better compression ratio comparing to
+/// Prometheus histogram buckets with `le` labels, since they don't include counters
+/// for all the previous buckets.
+///
+/// Zero histogram is usable.
+#[allow(missing_debug_implementations)]
 #[derive(Clone)]
 pub struct VMHistogram {
     inner: Arc<Mutex<Inner>>,
@@ -59,13 +110,12 @@ pub struct VMHistogram {
 }
 
 impl VMHistogram {
-    #[allow(missing_docs)]
-    pub fn with_opts(opts: &Opts) -> crate::Result<Self> {
-        VMHistogram::with_opts_and_label_values(opts, &[])
+    /// `with_opts` creates a [`VMHistogram`] with the `opts` options.
+    pub fn with_opts(opts: Opts) -> crate::Result<Self> {
+        VMHistogram::with_opts_and_label_values(&opts, &[])
     }
 
-    #[allow(missing_docs)]
-    pub fn with_opts_and_label_values(opts: &Opts, label_values: &[&str]) -> crate::Result<Self> {
+    fn with_opts_and_label_values(opts: &Opts, label_values: &[&str]) -> crate::Result<Self> {
         let desc = opts.describe()?;
 
         let label_pairs = make_label_pairs(&desc, label_values)?;
@@ -76,7 +126,8 @@ impl VMHistogram {
         })
     }
 
-    #[allow(missing_docs)]
+    /// Add a single observation to the [`VMHistogram`]
+    /// Negative values and NaNs are ignored.
     pub fn observe(&self, value: f64) {
         if value.is_nan() || value.is_sign_negative() {
             return;
@@ -159,23 +210,37 @@ impl Collector for VMHistogram {
     }
 }
 
-#[allow(missing_docs)]
+/// A [`Collector`] that bundles a set of VMHistograms that all share the
+/// same [`Desc`], but have different values for their variable labels. This is used
+/// if you want to count the same thing partitioned by various dimensions
+/// (e.g. HTTP request latencies, partitioned by status code and method).
 pub type VMHistogramVec = MetricVec<VMHistogramVecBuilder>;
 
 impl VMHistogramVec {
-    #[allow(missing_docs)]
+    /// Create a new [`VMHistogramVec`] based on the provided
+    /// [`Opts`] and partitioned by the given label names. At least
+    /// one label name must be provided.
     pub fn new(opts: Opts, label_names: &[&str]) -> crate::Result<VMHistogramVec> {
         let variable_names = label_names.iter().map(|s| (*s).to_owned()).collect();
         let opts = opts.variable_labels(variable_names);
-        let metric_vec =
-            MetricVec::create(proto::MetricType::HISTOGRAM, VMHistogramVecBuilder {}, opts)?;
+        let metric_vec = MetricVec::create(
+            proto::MetricType::VMHISTOGRAM,
+            VMHistogramVecBuilder {},
+            opts,
+        )?;
 
         Ok(metric_vec)
     }
 }
 
 impl Inner {
-    pub fn visit_nonzero_buckets<F>(&self, mut visitor: F)
+    /// `visit_nonzero_buckets` calls `visitor` for all buckets with non-zero counters.
+    ///
+    /// vmrange contains "<start>...<end>" string with bucket bounds. The lower bound
+    /// isn't included in the bucket, while the upper bound is included.
+    /// This is required to be compatible with Prometheus-style histogram buckets
+    /// with `le` (less or equal) labels.
+    fn visit_nonzero_buckets<F>(&self, mut visitor: F)
     where
         F: FnMut(&str, u64),
     {
@@ -195,6 +260,69 @@ impl Inner {
         }
         if self.upper > 0 {
             visitor(&UPPER_BUCKET_RANGE, self.upper)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::f64::EPSILON;
+
+    use crate::{Opts, VMHistogram, core::Collector, VMHistogramVec, Error};
+
+
+    #[test]
+    fn test_vmhistogram() {
+        let opts = Opts::new("test1", "test help")
+            .const_label("a", "1")
+            .const_label("b", "2");
+        let histogram = VMHistogram::with_opts(opts).unwrap();
+        histogram.observe(1.0);
+        histogram.observe(3.0);
+        histogram.observe(5.0);
+
+        let mut mfs = histogram.collect();
+        assert_eq!(mfs.len(), 1);
+
+        let mf = mfs.pop().unwrap();
+        let m = mf.get_metric().get(0).unwrap();
+        assert_eq!(m.get_label().len(), 2);
+        let proto_histogram = m.get_vm_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 3);
+        assert!(9.0 - proto_histogram.get_sample_sum() < EPSILON);
+    }
+
+    #[test]
+    fn test_vmhistogram_vec_with_label_values() {
+        let vec = VMHistogramVec::new(
+            Opts::new("test_histogram_vec", "test histogram vec help"),
+            &["l1", "l2"],
+        )
+        .unwrap();
+
+        assert!(vec.remove_label_values(&["v1", "v2"]).is_err());
+        vec.with_label_values(&["v1", "v2"]).observe(1.0);
+        assert!(vec.remove_label_values(&["v1", "v2"]).is_ok());
+
+        assert!(vec.remove_label_values(&["v1"]).is_err());
+        assert!(vec.remove_label_values(&["v1", "v3"]).is_err());
+    }
+
+    #[test]
+    fn test_error_on_inconsistent_label_cardinality() {
+        let hist = VMHistogram::with_opts(
+            opts!(
+                "example_histogram",
+                "Used as an example",
+            )
+            .variable_label("example_variable"),
+        );
+
+        if let Err(Error::InconsistentCardinality { expect, got }) = hist {
+            assert_eq!(1, expect);
+            assert_eq!(0, got);
+        } else {
+            panic!("Expected InconsistentCardinality error.")
         }
     }
 }

--- a/src/vmhistogram.rs
+++ b/src/vmhistogram.rs
@@ -50,7 +50,7 @@ struct Inner {
     sum: f64,
 }
 
-#[allow(missing_debug_implementations)]
+#[allow(missing_debug_implementations, missing_docs)]
 #[derive(Clone)]
 pub struct VMHistogram {
     inner: Arc<Mutex<Inner>>,
@@ -59,10 +59,12 @@ pub struct VMHistogram {
 }
 
 impl VMHistogram {
+    #[allow(missing_docs)]
     pub fn with_opts(opts: &Opts) -> crate::Result<Self> {
         VMHistogram::with_opts_and_label_values(opts, &[])
     }
 
+    #[allow(missing_docs)]
     pub fn with_opts_and_label_values(opts: &Opts, label_values: &[&str]) -> crate::Result<Self> {
         let desc = opts.describe()?;
 
@@ -74,6 +76,7 @@ impl VMHistogram {
         })
     }
 
+    #[allow(missing_docs)]
     pub fn observe(&self, value: f64) {
         if value.is_nan() || value.is_sign_negative() {
             return;
@@ -156,6 +159,7 @@ impl Collector for VMHistogram {
     }
 }
 
+#[allow(missing_docs)]
 pub type VMHistogramVec = MetricVec<VMHistogramVecBuilder>;
 
 impl VMHistogramVec {


### PR DESCRIPTION
Mostly copied from the VictoriaMetrics [go source](https://github.com/VictoriaMetrics/metrics/blob/ae1e9d8058de94e5622ccee515ece7992d67d209/histogram.go) and tests/comments are copied from the regular Histogram implementation.

If this looks good, I'll send a PR to update our repo to use this fork.