### PR TITLE
Add inactivity-based series eviction for MetricVec

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use crate::atomic64::{Atomic, AtomicF64, AtomicU64, Number};
 use crate::desc::Desc;
 use crate::errors::Result;
-use crate::metrics::{Collector, LocalMetric, Metric, Opts};
+use crate::metrics::{Collector, LastObserved, LocalMetric, Metric, Opts};
 use crate::proto;
 use crate::value::{Value, ValueType};
 use crate::vec::{MetricVec, MetricVecBuilder};
@@ -100,6 +100,12 @@ impl<P: Atomic> Collector for GenericCounter<P> {
 impl<P: Atomic> Metric for GenericCounter<P> {
     fn metric(&self) -> proto::Metric {
         self.v.metric()
+    }
+}
+
+impl<P: Atomic> LastObserved for GenericCounter<P> {
+    fn last_observed_ms(&self) -> u64 {
+        self.v.last_observed_ms()
     }
 }
 

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::atomic64::{Atomic, AtomicF64, AtomicI64, Number};
 use crate::desc::Desc;
 use crate::errors::Result;
-use crate::metrics::{Collector, Metric, Opts};
+use crate::metrics::{Collector, LastObserved, Metric, Opts};
 use crate::proto;
 use crate::value::{Value, ValueType};
 use crate::vec::{MetricVec, MetricVecBuilder};
@@ -103,6 +103,12 @@ impl<P: Atomic> Collector for GenericGauge<P> {
 impl<P: Atomic> Metric for GenericGauge<P> {
     fn metric(&self) -> proto::Metric {
         self.v.metric()
+    }
+}
+
+impl<P: Atomic> LastObserved for GenericGauge<P> {
+    fn last_observed_ms(&self) -> u64 {
+        self.v.last_observed_ms()
     }
 }
 

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -13,8 +13,9 @@ use std::time::{Duration, Instant as StdInstant};
 use crate::atomic64::{Atomic, AtomicF64, AtomicU64};
 use crate::desc::{Desc, Describer};
 use crate::errors::{Error, Result};
-use crate::metrics::{Collector, LocalMetric, Metric, Opts};
+use crate::metrics::{Collector, LastObserved, LocalMetric, Metric, Opts};
 use crate::proto;
+use crate::timer;
 use crate::value::make_label_pairs;
 use crate::vec::{MetricVec, MetricVecBuilder};
 
@@ -325,6 +326,11 @@ pub struct HistogramCore {
     shards: [Shard; 2],
 
     upper_bounds: Vec<f64>,
+
+    /// Milliseconds (on the [`timer::now_millis`] clock) of the most
+    /// recent observation. Used by the [`Evictable`](crate::core::Evictable)
+    /// sweep to drop idle label sets.
+    last_observed_ms: StdAtomicU64,
 }
 
 impl HistogramCore {
@@ -352,7 +358,15 @@ impl HistogramCore {
             shards: [Shard::new(buckets.len()), Shard::new(buckets.len())],
 
             upper_bounds: buckets,
+
+            last_observed_ms: StdAtomicU64::new(0),
         })
+    }
+
+    /// Returns the millisecond timestamp of the most recent
+    /// observation on the [`timer::now_millis`] clock.
+    pub(crate) fn last_observed_ms(&self) -> u64 {
+        self.last_observed_ms.load(Ordering::Relaxed)
     }
 
     /// Record a given observation (f64) in the histogram.
@@ -369,6 +383,9 @@ impl HistogramCore {
         // To ensure the above, this `inc` needs to use `Acquire` ordering to
         // force anything below this line to stay below it.
         let (shard_index, _count) = self.shard_and_count.inc(Ordering::Acquire);
+
+        self.last_observed_ms
+            .store(timer::now_millis(), Ordering::Relaxed);
 
         let shard: &Shard = &self.shards[usize::from(shard_index)];
 
@@ -773,6 +790,12 @@ impl Collector for Histogram {
         m.set_metric(vec![self.metric()]);
 
         vec![m]
+    }
+}
+
+impl LastObserved for Histogram {
+    fn last_observed_ms(&self) -> u64 {
+        self.core.last_observed_ms()
     }
 }
 

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -359,7 +359,7 @@ impl HistogramCore {
 
             upper_bounds: buckets,
 
-            last_observed_ms: StdAtomicU64::new(0),
+            last_observed_ms: StdAtomicU64::new(timer::now_millis()),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ pub mod core {
     };
     pub use super::desc::{Desc, Describer};
     pub use super::gauge::{GenericGauge, GenericGaugeVec};
-    pub use super::metrics::{Collector, Metric, Opts};
+    pub use super::metrics::{Collector, Evictable, LastObserved, Metric, Opts};
     pub use super::vec::{MetricVec, MetricVecBuilder};
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -27,6 +27,43 @@ pub trait Metric: Sync + Send + Clone {
     fn metric(&self) -> proto::Metric;
 }
 
+/// A [`Metric`] that records when it was most recently written to.
+///
+/// Implemented by metric types that update an atomic timestamp on every
+/// observation (`observe`/`inc`/`set`/...). Used together with
+/// [`Evictable`] on [`MetricVec`](crate::core::MetricVec) to drop label
+/// sets that have gone idle.
+///
+/// The timestamp uses the same clock as [`crate::timer::now_millis`]:
+/// milliseconds since a fixed per-process anchor (process start).
+pub trait LastObserved {
+    /// Returns the millisecond timestamp of the most recent write to
+    /// this metric, on the [`crate::timer::now_millis`] clock. Returns
+    /// `0` if the metric has never been written to.
+    fn last_observed_ms(&self) -> u64;
+}
+
+/// A collection of metric series that supports bulk removal of label
+/// sets whose backing [`LastObserved`] timestamp is older than a
+/// threshold.
+///
+/// Implemented for [`MetricVec<T>`](crate::core::MetricVec) when
+/// `T::M: LastObserved`. Trait objects (`Arc<dyn Evictable>`) let a
+/// downstream sweeper hold a heterogeneous list of metric vectors and
+/// call [`evict_stale_before`](Self::evict_stale_before) on each
+/// without knowing their concrete type.
+pub trait Evictable: Sync + Send {
+    /// Removes children whose `last_observed_ms` is strictly less than
+    /// `threshold_ms`. Returns the number of series removed.
+    ///
+    /// `threshold_ms` is on the [`crate::timer::now_millis`] clock.
+    /// A typical caller computes it as `now_millis() - ttl.as_millis()`.
+    fn evict_stale_before(&self, threshold_ms: u64) -> usize;
+
+    /// Returns the current number of live label sets.
+    fn cardinality(&self) -> usize;
+}
+
 /// An interface models a Metric only usable in single thread environment.
 pub trait LocalMetric {
     /// Flush the local metrics to the global one.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -38,8 +38,9 @@ pub trait Metric: Sync + Send + Clone {
 /// milliseconds since a fixed per-process anchor (process start).
 pub trait LastObserved {
     /// Returns the millisecond timestamp of the most recent write to
-    /// this metric, on the [`crate::timer::now_millis`] clock. Returns
-    /// `0` if the metric has never been written to.
+    /// this metric, on the [`crate::timer::now_millis`] clock.
+    /// Initialized to the creation time so a newly-created (but
+    /// not-yet-written) child is not immediately swept.
     fn last_observed_ms(&self) -> u64;
 }
 

--- a/src/proto_ext.rs
+++ b/src/proto_ext.rs
@@ -279,4 +279,3 @@ impl From<MetricType> for Option<EnumOrUnknown<MetricType>> {
         Some(EnumOrUnknown::from(value))
     }
 }
-

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -77,9 +77,12 @@ mod tests {
 
     #[test]
     fn test_time_update() {
-        assert_eq!(super::recent_millis(), 0);
+        // RECENT is process-global and any other test that touches a
+        // metric (which now records `last_observed_ms` via
+        // `now_millis`) will have already advanced it, so we don't
+        // assert it starts at zero.
         let now = super::now_millis();
-        assert_eq!(super::recent_millis(), now);
+        assert!(super::recent_millis() >= now);
         super::ensure_updater();
         thread::sleep(super::CHECK_UPDATE_INTERVAL * 2);
         assert!(super::recent_millis() > now);

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,10 +1,13 @@
 // Copyright 2014 The Prometheus Authors
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::sync::atomic::{AtomicU64 as StdAtomicU64, Ordering};
+
 use crate::atomic64::{Atomic, Number};
 use crate::desc::{Desc, Describer};
 use crate::errors::{Error, Result};
 use crate::proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType};
+use crate::timer;
 
 /// `ValueType` is an enumeration of metric types that represent a simple value
 /// for [`Counter`] and [`Gauge`].
@@ -34,6 +37,11 @@ pub struct Value<P: Atomic> {
     pub val: P,
     pub val_type: ValueType,
     pub label_pairs: Vec<LabelPair>,
+    /// Milliseconds (on the [`timer::now_millis`] clock) of the most
+    /// recent write. Updated on every `set`/`inc_by`/`dec_by`. Used by
+    /// the [`Evictable`](crate::core::Evictable) sweep on metric
+    /// vectors.
+    pub last_observed_ms: StdAtomicU64,
 }
 
 impl<P: Atomic> Value<P> {
@@ -51,6 +59,7 @@ impl<P: Atomic> Value<P> {
             val: P::new(val),
             val_type,
             label_pairs,
+            last_observed_ms: StdAtomicU64::new(0),
         })
     }
 
@@ -62,11 +71,13 @@ impl<P: Atomic> Value<P> {
     #[inline]
     pub fn set(&self, val: P::T) {
         self.val.set(val);
+        self.touch();
     }
 
     #[inline]
     pub fn inc_by(&self, val: P::T) {
         self.val.inc_by(val);
+        self.touch();
     }
 
     #[inline]
@@ -81,7 +92,19 @@ impl<P: Atomic> Value<P> {
 
     #[inline]
     pub fn dec_by(&self, val: P::T) {
-        self.val.dec_by(val)
+        self.val.dec_by(val);
+        self.touch();
+    }
+
+    #[inline]
+    fn touch(&self) {
+        self.last_observed_ms
+            .store(timer::now_millis(), Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn last_observed_ms(&self) -> u64 {
+        self.last_observed_ms.load(Ordering::Relaxed)
     }
 
     pub fn metric(&self) -> Metric {

--- a/src/value.rs
+++ b/src/value.rs
@@ -59,7 +59,7 @@ impl<P: Atomic> Value<P> {
             val: P::new(val),
             val_type,
             label_pairs,
-            last_observed_ms: StdAtomicU64::new(0),
+            last_observed_ms: StdAtomicU64::new(timer::now_millis()),
         })
     }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 
 use crate::desc::{Desc, Describer};
 use crate::errors::{Error, Result};
-use crate::metrics::{Collector, Metric};
+use crate::metrics::{Collector, Evictable, LastObserved, Metric};
 use crate::nohash::BuildNoHashHasher;
 use crate::proto::{MetricFamily, MetricType};
 
@@ -356,13 +356,48 @@ impl<T: MetricVecBuilder> Collector for MetricVec<T> {
     }
 }
 
+impl<T: MetricVecBuilder> MetricVec<T>
+where
+    T::M: LastObserved,
+{
+    /// Removes children whose `last_observed_ms` is strictly less than
+    /// `threshold_ms`. Returns the number of series removed.
+    ///
+    /// Holds the children write lock for the duration of the sweep.
+    /// Concurrent scrapes (`collect`) take the same lock for read and
+    /// will block briefly; concurrent observations either preceded the
+    /// lock (already recorded) or follow it (recreate the child).
+    pub fn evict_stale_before(&self, threshold_ms: u64) -> usize {
+        let mut children = self.v.children.write();
+        let before = children.len();
+        children.retain(|_, child| child.last_observed_ms() >= threshold_ms);
+        before - children.len()
+    }
+}
+
+impl<T: MetricVecBuilder> Evictable for MetricVec<T>
+where
+    T::M: LastObserved,
+{
+    fn evict_stale_before(&self, threshold_ms: u64) -> usize {
+        MetricVec::evict_stale_before(self, threshold_ms)
+    }
+
+    fn cardinality(&self) -> usize {
+        self.v.children.read().len()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
-    use crate::counter::CounterVec;
+    use crate::counter::{CounterVec, IntCounterVec};
     use crate::gauge::GaugeVec;
-    use crate::metrics::{Metric, Opts};
+    use crate::histogram::{HistogramOpts, HistogramVec};
+    use crate::metrics::{Evictable, Metric, Opts};
+    use crate::timer;
+    use crate::vmhistogram::VMHistogramVec;
 
     #[test]
     fn test_counter_vec_with_labels() {
@@ -562,6 +597,146 @@ mod tests {
 
         assert!(vec.remove_label_values(&[v1.clone()]).is_err());
         assert!(vec.remove_label_values(&[v1.clone(), v3.clone()]).is_err());
+    }
+
+    #[test]
+    fn test_evict_stale_counter_vec() {
+        let vec = IntCounterVec::new(
+            Opts::new("test_evict_counter", "evict counter test"),
+            &["k"],
+        )
+        .unwrap();
+        vec.with_label_values(&["stale"]).inc();
+        vec.with_label_values(&["fresh"]).inc();
+        assert_eq!(vec.cardinality(), 2);
+
+        // Advance the clock past the stale observation so that the
+        // sweep threshold lands between the two writes.
+        let cutoff = timer::now_millis() + 1;
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        vec.with_label_values(&["fresh"]).inc();
+
+        let removed = vec.evict_stale_before(cutoff);
+        assert_eq!(removed, 1);
+        assert_eq!(vec.cardinality(), 1);
+        // The surviving series is still readable.
+        assert_eq!(vec.with_label_values(&["fresh"]).get(), 2);
+    }
+
+    #[test]
+    fn test_evict_stale_histogram_vec() {
+        let vec = HistogramVec::new(
+            HistogramOpts::new("test_evict_histogram", "evict histogram test"),
+            &["k"],
+        )
+        .unwrap();
+        vec.with_label_values(&["stale"]).observe(0.5);
+        vec.with_label_values(&["fresh"]).observe(0.5);
+        assert_eq!(vec.cardinality(), 2);
+
+        let cutoff = timer::now_millis() + 1;
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        vec.with_label_values(&["fresh"]).observe(0.5);
+
+        assert_eq!(vec.evict_stale_before(cutoff), 1);
+        assert_eq!(vec.cardinality(), 1);
+    }
+
+    #[test]
+    fn test_evict_stale_vmhistogram_vec() {
+        let vec = VMHistogramVec::new(
+            Opts::new("test_evict_vmhistogram", "evict vmhistogram test"),
+            &["k"],
+        )
+        .unwrap();
+        vec.with_label_values(&["stale"]).observe(1.0);
+        vec.with_label_values(&["fresh"]).observe(1.0);
+        assert_eq!(vec.cardinality(), 2);
+
+        let cutoff = timer::now_millis() + 1;
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        vec.with_label_values(&["fresh"]).observe(1.0);
+
+        assert_eq!(vec.evict_stale_before(cutoff), 1);
+        assert_eq!(vec.cardinality(), 1);
+    }
+
+    #[test]
+    fn test_evict_stale_gauge_vec() {
+        let vec = GaugeVec::new(Opts::new("test_evict_gauge", "evict gauge test"), &["k"]).unwrap();
+        vec.with_label_values(&["stale"]).set(1.0);
+        vec.with_label_values(&["fresh"]).set(1.0);
+
+        let cutoff = timer::now_millis() + 1;
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        vec.with_label_values(&["fresh"]).set(2.0);
+
+        assert_eq!(vec.evict_stale_before(cutoff), 1);
+        assert_eq!(vec.cardinality(), 1);
+    }
+
+    #[test]
+    fn test_evict_via_dyn_evictable() {
+        let cv = IntCounterVec::new(Opts::new("dyn_evict_counter", "h"), &["k"]).unwrap();
+        cv.with_label_values(&["a"]).inc();
+        let hv = HistogramVec::new(HistogramOpts::new("dyn_evict_histogram", "h"), &["k"]).unwrap();
+        hv.with_label_values(&["a"]).observe(0.5);
+
+        let evictables: Vec<std::sync::Arc<dyn Evictable>> = vec![
+            std::sync::Arc::new(cv.clone()),
+            std::sync::Arc::new(hv.clone()),
+        ];
+
+        let cutoff = timer::now_millis() + 1;
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let removed: usize = evictables
+            .iter()
+            .map(|e| e.evict_stale_before(cutoff))
+            .sum();
+        assert_eq!(removed, 2);
+        assert_eq!(cv.cardinality(), 0);
+        assert_eq!(hv.cardinality(), 0);
+    }
+
+    #[test]
+    fn test_evict_concurrent_observe() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+        let vec =
+            Arc::new(IntCounterVec::new(Opts::new("test_evict_concurrent", "h"), &["k"]).unwrap());
+        // Pre-create both label sets.
+        vec.with_label_values(&["alive"]).inc();
+        vec.with_label_values(&["doomed"]).inc();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let writer = {
+            let vec = Arc::clone(&vec);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..10_000 {
+                    vec.with_label_values(&["alive"]).inc();
+                }
+            })
+        };
+        let evicter = {
+            let vec = Arc::clone(&vec);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                let mut total = 0;
+                for _ in 0..50 {
+                    // Evict anything older than "now", which excludes
+                    // anything the writer just touched.
+                    total += vec.evict_stale_before(timer::now_millis());
+                }
+                total
+            })
+        };
+        writer.join().unwrap();
+        evicter.join().unwrap();
+        // The actively-written series must survive every sweep round.
+        assert!(vec.with_label_values(&["alive"]).get() >= 10_000);
     }
 
     #[test]

--- a/src/vmhistogram.rs
+++ b/src/vmhistogram.rs
@@ -22,6 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use std::sync::atomic::{AtomicU64 as StdAtomicU64, Ordering};
 use std::sync::Arc;
 
 use lazy_static::lazy_static;
@@ -32,7 +33,9 @@ use crate::{
         Atomic, AtomicF64, AtomicU64, Collector, Desc, Describer, Metric, MetricVec,
         MetricVecBuilder,
     },
+    metrics::LastObserved,
     proto::{self, LabelPair},
+    timer,
     value::make_label_pairs,
     Opts,
 };
@@ -101,6 +104,11 @@ pub struct VMHistogram {
     inner: Arc<RwLock<Inner>>,
     desc: Arc<Desc>,
     label_pairs: Arc<Vec<LabelPair>>,
+    /// Milliseconds (on the [`timer::now_millis`] clock) of the most
+    /// recent observation. Lives outside the inner `RwLock` so the
+    /// `observe` hot path doesn't have to wait on the lock to record
+    /// activity.
+    last_observed_ms: Arc<StdAtomicU64>,
 }
 
 impl VMHistogram {
@@ -120,6 +128,7 @@ impl VMHistogram {
             inner: Default::default(),
             desc: Arc::new(desc),
             label_pairs: Arc::new(label_pairs),
+            last_observed_ms: Arc::new(StdAtomicU64::new(0)),
         })
     }
 
@@ -129,6 +138,8 @@ impl VMHistogram {
         if value.is_nan() || value < 0.0 {
             return;
         }
+        self.last_observed_ms
+            .store(timer::now_millis(), Ordering::Relaxed);
         let bucket_idx = (value.log10() - E_10_MIN as f64) * BUCKETS_PER_DECIMAL as f64;
         let inner = self.inner.read();
         inner.sum.inc_by(value);
@@ -188,6 +199,12 @@ impl Metric for VMHistogram {
         let h = self.proto();
         m.set_vm_histogram(h);
         m
+    }
+}
+
+impl LastObserved for VMHistogram {
+    fn last_observed_ms(&self) -> u64 {
+        self.last_observed_ms.load(Ordering::Relaxed)
     }
 }
 

--- a/src/vmhistogram.rs
+++ b/src/vmhistogram.rs
@@ -128,7 +128,7 @@ impl VMHistogram {
             inner: Default::default(),
             desc: Arc::new(desc),
             label_pairs: Arc::new(label_pairs),
-            last_observed_ms: Arc::new(StdAtomicU64::new(0)),
+            last_observed_ms: Arc::new(StdAtomicU64::new(timer::now_millis())),
         })
     }
 


### PR DESCRIPTION
Adds two traits so a downstream sweeper can drop idle label sets from `MetricVec`:

- `LastObserved` — implemented on `Counter`, `Gauge`, `IntCounter`, `IntGauge`, `Histogram`, `VMHistogram`. Every observe/inc/set/dec does a `Relaxed` store of `timer::now_millis()`. New children initialize the timestamp to creation time, not 0, so a sweep right after `with_label_values` doesn't immediately evict them.
- `Evictable` — blanket impl on `MetricVec<T>` where `T::M: LastObserved`. Bulk-removes children whose `last_observed_ms` is below a threshold. Exposed both as an inherent method and as a `dyn Evictable` trait object so the consumer can hold a heterogeneous list behind `Arc<dyn Evictable>`.

Notes:
- `Collector`/`Metric` are untouched.
- Sweep takes the existing `RwLock<HashMap>` write lock on `MetricVecCore::children` for the `retain` pass. An observation racing eviction either preceded the lock (recorded) or follows it (re-creates the child).
- `VMHistogram`'s timestamp lives on the outer struct so the store doesn't wait on the inner `RwLock`.
- One pre-existing timer test was relaxed (`recent_millis()` is no longer guaranteed zero at process start now that every observation touches it).

Consumer side is in get-convex/convex#51888 — gates this behind a 15-min default TTL and a tokio sweeper.